### PR TITLE
Upgrading javaewah.

### DIFF
--- a/java_benchmark/pom.xml
+++ b/java_benchmark/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.googlecode.javaewah</groupId>
             <artifactId>JavaEWAH</artifactId>
-            <version>1.0.7</version>
+            <version>[1.0.8,)</version>
         </dependency>
         <dependency>
             <groupId>org.easytesting</groupId>


### PR DESCRIPTION
Latest version of javaewah should have better performance in the instances where we intersect a tiny bitmap with a complex one. In effect, the Java code is now more like the C++ code. It still does zero padding (which the C++ skips), but it does it fast (in constant time) instead of parsing the big input.

Let me know if it helps.
